### PR TITLE
bumped kafka protocol to version 1.0.0.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func mustNewKafka(brokerString string) sarama.Client {
 	log.WithField("brokers.bootstrap", brokers).Info("connecting to cluster with bootstrap hosts")
 
 	cfg := sarama.NewConfig()
-	cfg.Version = sarama.V0_10_0_0
+	cfg.Version = sarama.V1_0_0_0
 	client, err := sarama.NewClient(brokers, cfg)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Sarama now support Kafka brokers up to version 1.0.0.0
Kafka brokers will complain (rebalance) when consumers with different versions runs in parallel. As Kafka provides version compatibility, there should be no side effect